### PR TITLE
Fix tests for Swift 3.1

### DIFF
--- a/Sources/include/module.modulemap
+++ b/Sources/include/module.modulemap
@@ -5,7 +5,7 @@ module HTMLKit {
 	export *
 
 	explicit module Private {
-		header "CSSCodePoints.h"
+		textual header "CSSCodePoints.h"
 		header "CSSInputStream.h"
 		header "HTMLCharacterToken.h"
 		header "HTMLCommentToken.h"
@@ -22,7 +22,7 @@ module HTMLKit {
 		header "HTMLTagToken.h"
 		header "HTMLToken.h"
 		header "HTMLTokenizer.h"
-		header "HTMLTokenizerCharacters.h"
+		textual header "HTMLTokenizerCharacters.h"
 		header "HTMLTokenizerEntities.h"
 		header "HTMLTokenizerStates.h"
 		header "HTMLTokens.h"

--- a/Tests/HTMLKitTests/CSSSelectorParserTests.m
+++ b/Tests/HTMLKitTests/CSSSelectorParserTests.m
@@ -7,7 +7,7 @@
 //
 
 #import <XCTest/XCTest.h>
-#import <HTMLKit/HTMLKit.h>
+#import "HTMLKit.h"
 #import "CSSSelectorTest.h"
 #import "CSSSelectorParser.h"
 

--- a/Tests/HTMLKitTests/HTML5LibTokenizerTest.m
+++ b/Tests/HTMLKitTests/HTML5LibTokenizerTest.m
@@ -7,6 +7,7 @@
 //
 
 #import "HTML5LibTokenizerTest.h"
+#import "HTMLOrderedDictionary.h"
 #import "HTMLTokenizerStates.h"
 #import "HTMLTokens.h"
 #import "HTMLKitTestUtil.h"


### PR DESCRIPTION
Now all tests pass on Swift 3.1
Followup from #7 (rebased to branch 'develop')