### PR TITLE
Fixed error with operator precedence in Xcode 12

### DIFF
--- a/Sources/HTMLNode.m
+++ b/Sources/HTMLNode.m
@@ -383,16 +383,16 @@ NSString * const RemoveChildNode = @"-removeChildNode:";
 	}
 
 	if (self.ownerDocument != otherNode.ownerDocument) {
-		return (HTMLDocumentPositionDisconnected | HTMLDocumentPositionImplementationSpecific |
-				self.hash < otherNode.hash ? HTMLDocumentPositionPreceding : HTMLDocumentPositionFollowing);
+		return ((HTMLDocumentPositionDisconnected | HTMLDocumentPositionImplementationSpecific |
+				self.hash < otherNode.hash) ? HTMLDocumentPositionPreceding : HTMLDocumentPositionFollowing);
 	}
 
 	NSArray *ancestors1 = GetAncestorNodes(self);
 	NSArray *ancestors2 = GetAncestorNodes(otherNode);
 
 	if (ancestors1.lastObject != ancestors2.lastObject) {
-		return (HTMLDocumentPositionDisconnected | HTMLDocumentPositionImplementationSpecific |
-				self.hash < otherNode.hash ? HTMLDocumentPositionPreceding : HTMLDocumentPositionFollowing);
+		return ((HTMLDocumentPositionDisconnected | HTMLDocumentPositionImplementationSpecific |
+				self.hash < otherNode.hash) ? HTMLDocumentPositionPreceding : HTMLDocumentPositionFollowing);
 	}
 
 	NSUInteger index1 = ancestors1.count;

--- a/Tests/HTMLKitTests/HTMLNodesTests.m
+++ b/Tests/HTMLKitTests/HTMLNodesTests.m
@@ -495,9 +495,7 @@
 	XCTAssertTrue([paragraph compareDocumentPositionWithNode:paragraph] == HTMLDocumentPositionEquivalent);
 
 	HTMLElement *element = [HTMLElement new];
-	XCTAssertTrue([paragraph compareDocumentPositionWithNode:element] ==
-				  (HTMLDocumentPositionDisconnected | HTMLDocumentPositionImplementationSpecific |
-				   paragraph.hash < element.hash ? HTMLDocumentPositionPreceding: HTMLDocumentPositionFollowing));
+	XCTAssertTrue([paragraph compareDocumentPositionWithNode:element] == HTMLDocumentPositionPreceding);
 
 	XCTAssertTrue([paragraph compareDocumentPositionWithNode:image] == HTMLDocumentPositionPreceding);
 	XCTAssertTrue([anchor compareDocumentPositionWithNode:image] == HTMLDocumentPositionPreceding);


### PR DESCRIPTION
Build fails in Xcode 12 beta 6 due to relative precedence of operators `?:` and `|`.
I also modified the test to be more straightforward what the result tested withing that assert should be, instead of having the same logic duplicated in the method and in the test.