### PR TITLE
[Fix] improper serialization of non-breaking space (0x00A0).

### DIFF
--- a/Sources/HTMLSerializer.m
+++ b/Sources/HTMLSerializer.m
@@ -107,7 +107,7 @@
 	[element.attributes enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
 		NSMutableString *escaped = [value mutableCopy];
 		[escaped replaceOccurrencesOfString:@"&" withString:@"&amp;" options:0 range:NSMakeRange(0, escaped.length)];
-		[escaped replaceOccurrencesOfString:@"0x00A0" withString:@"&nbsp;" options:0 range:NSMakeRange(0, escaped.length)];
+		[escaped replaceOccurrencesOfString:@"\u00A0" withString:@"&nbsp;" options:0 range:NSMakeRange(0, escaped.length)];
 		[escaped replaceOccurrencesOfString:@"\"" withString:@"&quot;" options:0 range:NSMakeRange(0, escaped.length)];
 
 		[_result appendFormat:@" %@=\"%@\"", key, escaped];
@@ -135,7 +135,7 @@
 	} else {
 		NSMutableString *escaped = [text.data mutableCopy];
 		[escaped replaceOccurrencesOfString:@"&" withString:@"&amp;" options:0 range:NSMakeRange(0, escaped.length)];
-		[escaped replaceOccurrencesOfString:@"\00A0" withString:@"&nbsp;" options:0 range:NSMakeRange(0, escaped.length)];
+		[escaped replaceOccurrencesOfString:@"\u00A0" withString:@"&nbsp;" options:0 range:NSMakeRange(0, escaped.length)];
 		[escaped replaceOccurrencesOfString:@"<" withString:@"&lt;" options:0 range:NSMakeRange(0, escaped.length)];
 		[escaped replaceOccurrencesOfString:@">" withString:@"&gt;" options:0 range:NSMakeRange(0, escaped.length)];
 		[_result appendString:escaped];


### PR DESCRIPTION
Fixes issues with serializing U+00A0 (Non-breaking space) character to &nbsp; entity

The specification for the unicode for U+00A0  is incorrect in both methods that attempt the string replacement